### PR TITLE
GitHub Actions CI を設定する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests
+        run: uv run pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,7 @@ class TestCLIBuild:
 
             # H3 以下は含まれない
             map_path = Path(tmpdir) / "MAP.json"
-            data = json.loads(map_path.read_text())
+            data = json.loads(map_path.read_text(encoding="utf-8"))
             levels = [entry["level"] for entry in data]
             assert 3 not in levels
 
@@ -148,14 +148,14 @@ class TestCLIBuild:
 
             # MAP.json にカスタムプレフィックスのIDが含まれる
             map_path = Path(tmpdir) / "MAP.json"
-            data = json.loads(map_path.read_text())
+            data = json.loads(map_path.read_text(encoding="utf-8"))
             ids = [entry.get("id") for entry in data]
             assert "DOC1" in ids
             assert "DOC2" in ids
 
             # INDEX.md にもカスタムプレフィックスのIDが含まれる
             index_path = Path(tmpdir) / "INDEX.md"
-            content = index_path.read_text()
+            content = index_path.read_text(encoding="utf-8")
             assert "[DOC1]" in content
             assert "[DOC2]" in content
 
@@ -172,7 +172,7 @@ class TestCLIOutput:
             )
 
             index_path = Path(tmpdir) / "INDEX.md"
-            content = index_path.read_text()
+            content = index_path.read_text(encoding="utf-8")
 
             # 必須セクション
             assert "# Index:" in content
@@ -192,7 +192,7 @@ class TestCLIOutput:
             )
 
             map_path = Path(tmpdir) / "MAP.json"
-            data = json.loads(map_path.read_text())
+            data = json.loads(map_path.read_text(encoding="utf-8"))
 
             assert isinstance(data, list)
             assert len(data) > 0
@@ -227,7 +227,7 @@ class TestCLIOutput:
             assert len(part_files) > 0
 
             # 最初のパートファイルを確認
-            content = part_files[0].read_text()
+            content = part_files[0].read_text(encoding="utf-8")
 
             # ヘッダ
             assert "<!--" in content
@@ -255,13 +255,13 @@ class TestCLIJapanese:
 
             # INDEX.md に日本語が含まれる
             index_path = Path(tmpdir) / "INDEX.md"
-            content = index_path.read_text()
+            content = index_path.read_text(encoding="utf-8")
             assert "日本語ドキュメント" in content
             assert "概要" in content
 
             # MAP.json に日本語が含まれる
             map_path = Path(tmpdir) / "MAP.json"
-            data = json.loads(map_path.read_text())
+            data = json.loads(map_path.read_text(encoding="utf-8"))
             sections = [entry["section"] for entry in data]
             assert "日本語ドキュメント" in sections
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -261,7 +261,7 @@ class TestGenerateIndex:
             output_path = Path(tmpdir) / "INDEX.md"
             generate_index(sections, [], str(output_path), "test.md")
 
-            content = output_path.read_text()
+            content = output_path.read_text(encoding="utf-8")
 
             # ヘッダ
             assert "# Index: test.md" in content
@@ -286,7 +286,7 @@ class TestGenerateIndex:
             output_path = Path(tmpdir) / "INDEX.md"
             generate_index(sections, warnings, str(output_path), "test.md")
 
-            content = output_path.read_text()
+            content = output_path.read_text(encoding="utf-8")
 
             assert "## Warnings" in content
             assert "[WARNING] Test warning 1" in content
@@ -322,7 +322,7 @@ class TestGenerateIndex:
             output_path = Path(tmpdir) / "INDEX.md"
             generate_index(sections, [], str(output_path), "test.md")
 
-            content = output_path.read_text()
+            content = output_path.read_text(encoding="utf-8")
 
             # 構造ツリーにIDが含まれる
             assert "[MD1] Main (L1–L10)" in content
@@ -362,7 +362,7 @@ class TestGenerateMap:
             generate_map(sections, tmpdir, str(output_path))
 
             # JSON をパース
-            data = json.loads(output_path.read_text())
+            data = json.loads(output_path.read_text(encoding="utf-8"))
 
             assert len(data) == 1
             entry = data[0]
@@ -405,7 +405,7 @@ class TestGenerateMap:
             generate_map(sections, tmpdir, str(output_path))
 
             # JSON をパース
-            data = json.loads(output_path.read_text())
+            data = json.loads(output_path.read_text(encoding="utf-8"))
 
             assert len(data) == 1
             entry = data[0]
@@ -441,7 +441,7 @@ class TestGenerateMap:
             generate_map(sections, tmpdir, str(output_path))
 
             # JSON をパース
-            data = json.loads(output_path.read_text())
+            data = json.loads(output_path.read_text(encoding="utf-8"))
 
             assert len(data) == 1
             entry = data[0]
@@ -458,23 +458,25 @@ class TestCalculateChecksum:
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".md") as f:
             f.write("Test content")
             f.flush()
+            tmp_path = f.name
 
-            checksum = calculate_checksum(f.name)
+        checksum = calculate_checksum(tmp_path)
 
-            assert len(checksum) == 64
-            assert all(c in "0123456789abcdef" for c in checksum)
+        assert len(checksum) == 64
+        assert all(c in "0123456789abcdef" for c in checksum)
 
-            os.unlink(f.name)
+        os.unlink(tmp_path)
 
     def test_checksum_deterministic(self):
         """同じ内容で同じチェックサム"""
         with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".md") as f:
             f.write("Same content")
             f.flush()
+            tmp_path = f.name
 
-            checksum1 = calculate_checksum(f.name)
-            checksum2 = calculate_checksum(f.name)
+        checksum1 = calculate_checksum(tmp_path)
+        checksum2 = calculate_checksum(tmp_path)
 
-            assert checksum1 == checksum2
+        assert checksum1 == checksum2
 
-            os.unlink(f.name)
+        os.unlink(tmp_path)


### PR DESCRIPTION
## Summary

- OS (ubuntu, windows, macos) × Python (3.9, 3.13) のマトリクスでCI を設定
- push / PR 時に `uv sync --all-extras` + `uv run pytest` を自動実行

Closes #5

## Test plan

- [ ] CI が全マトリクス (6パターン) で正常に完了すること
- [ ] ローカルパッケージ `add-line-numbers` の依存解決が通ること
- [ ] テストが全て pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)