### PR TITLE
feat: OpenAIプロバイダーにbase_url対応を追加しOpenAI互換APIへ接続可能にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - Unreleased
 
+### Added
+
+- **OpenAI-compatible API support**: Added a `base_url` field to `LLMConfig`, enabling connections to OpenAI-compatible APIs such as Moonshot AI's Kimi
+  - `OpenAIProvider` connects to the specified URL when `base_url` is set (defaults to the official OpenAI API when unset)
+  - Since some OpenAI-compatible APIs do not support `max_completion_tokens`, the provider falls back to the legacy `max_tokens` parameter when `base_url` is set
+  - `build_llm_config_from_env` now reads the `OPENAI_BASE_URL` environment variable, making compatible APIs available from the CLI as well
+
 ### Changed
 
 - **Moved version management to git tags** (#29): Removed the `versions/` directory that kept snapshots of older versions; only the latest code is now kept at the repository root

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -9,6 +9,13 @@
 
 ## [0.5.0] - Unreleased
 
+### 追加
+
+- **OpenAI 互換 API 対応**: `LLMConfig` に `base_url` フィールドを追加し、Moonshot AI（Kimi）等の OpenAI 互換 API に接続可能に
+  - `OpenAIProvider` が `base_url` 指定時にその URL へ接続（未指定時は従来どおり OpenAI 公式 API）
+  - OpenAI 互換 API には `max_completion_tokens` 未対応のものがあるため、`base_url` 指定時は従来の `max_tokens` パラメータで API を呼び出す
+  - `build_llm_config_from_env` が環境変数 `OPENAI_BASE_URL` を読み取り、CLI からも互換 API を利用可能に
+
 ### 変更
 
 - **バージョン管理を git tag へ移行**（#29）: 旧バージョンのスナップショットを保持していた `versions/` ディレクトリを削除し、リポジトリのルートで最新コードのみを管理する方針に変更

--- a/md2map/llm/config.py
+++ b/md2map/llm/config.py
@@ -12,6 +12,7 @@ class LLMConfig:
         provider: プロバイダー名 ("openai" | "anthropic" | "bedrock")
         model: モデルID
         api_key: API キー（Anthropic / OpenAI 用）
+        base_url: OpenAI 互換 API（Moonshot AI 等）の接続先 URL（OpenAI 用、未指定時は公式 API）
         access_key_id: アクセスキーID（Bedrock 用）
         secret_access_key: シークレットアクセスキー（Bedrock 用）
         region: リージョン（Bedrock 用）
@@ -21,6 +22,7 @@ class LLMConfig:
     provider: str
     model: str
     api_key: Optional[str] = None
+    base_url: Optional[str] = None
     access_key_id: Optional[str] = None
     secret_access_key: Optional[str] = None
     region: Optional[str] = None

--- a/md2map/llm/factory.py
+++ b/md2map/llm/factory.py
@@ -64,7 +64,12 @@ def build_llm_config_from_env(
             or os.getenv("OPENAI_MODEL")
             or "gpt-4o-mini"
         )
-        return LLMConfig(provider="openai", model=resolved_model, api_key=api_key)
+        return LLMConfig(
+            provider="openai",
+            model=resolved_model,
+            api_key=api_key,
+            base_url=os.getenv("OPENAI_BASE_URL"),
+        )
 
     elif provider == "anthropic":
         api_key = os.getenv("ANTHROPIC_API_KEY")

--- a/md2map/llm/openai_provider.py
+++ b/md2map/llm/openai_provider.py
@@ -5,7 +5,10 @@ from md2map.llm.config import LLMConfig
 
 
 class OpenAIProvider(BaseLLMProvider):
-    """OpenAI API を使用する LLM プロバイダー"""
+    """OpenAI API を使用する LLM プロバイダー
+
+    base_url を指定した場合は OpenAI 互換 API（Moonshot AI 等）に接続する。
+    """
 
     def __init__(self, config: LLMConfig) -> None:
         try:
@@ -18,17 +21,31 @@ class OpenAIProvider(BaseLLMProvider):
 
         self._model = config.model
         self._max_tokens = config.max_tokens
-        self._client = OpenAI(api_key=config.api_key)
+        self._base_url = config.base_url
+        if config.base_url:
+            self._client = OpenAI(api_key=config.api_key, base_url=config.base_url)
+        else:
+            self._client = OpenAI(api_key=config.api_key)
 
     def send_message(self, system_prompt: str, user_message: str) -> str:
-        response = self._client.chat.completions.create(
-            model=self._model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_message},
-            ],
-            max_completion_tokens=self._max_tokens,
-        )
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+        # OpenAI 互換 API には max_completion_tokens 未対応のものがあるため、
+        # base_url 指定時は従来の max_tokens パラメータを使用する
+        if self._base_url:
+            response = self._client.chat.completions.create(
+                model=self._model,
+                messages=messages,
+                max_tokens=self._max_tokens,
+            )
+        else:
+            response = self._client.chat.completions.create(
+                model=self._model,
+                messages=messages,
+                max_completion_tokens=self._max_tokens,
+            )
         if not response.choices or not response.choices[0].message.content:
             raise RuntimeError("OpenAI API returned empty response")
         return response.choices[0].message.content

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -56,9 +56,19 @@ class TestLLMConfig:
     def test_default_optional_fields(self):
         config = LLMConfig(provider="openai", model="gpt-4o-mini")
         assert config.api_key is None
+        assert config.base_url is None
         assert config.access_key_id is None
         assert config.secret_access_key is None
         assert config.region is None
+
+    def test_create_openai_compatible_config(self):
+        config = LLMConfig(
+            provider="openai",
+            model="kimi-k2-turbo-preview",
+            api_key="sk-test",
+            base_url="https://api.moonshot.ai/v1",
+        )
+        assert config.base_url == "https://api.moonshot.ai/v1"
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +131,20 @@ class TestBuildLLMConfigFromEnv:
     def test_openai_model_explicit(self):
         config = build_llm_config_from_env(provider="openai", model="gpt-4o-mini")
         assert config.model == "gpt-4o-mini"
+
+    @patch.dict(
+        os.environ,
+        {"OPENAI_API_KEY": "sk-env-key", "OPENAI_BASE_URL": "https://api.moonshot.ai/v1"},
+        clear=False,
+    )
+    def test_openai_base_url_from_env(self):
+        config = build_llm_config_from_env(provider="openai")
+        assert config.base_url == "https://api.moonshot.ai/v1"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env-key"}, clear=True)
+    def test_openai_base_url_default_none(self):
+        config = build_llm_config_from_env(provider="openai")
+        assert config.base_url is None
 
     @patch.dict(os.environ, {}, clear=True)
     def test_openai_missing_key_raises(self):
@@ -213,6 +237,63 @@ class TestOpenAIProviderAPICall:
         assert "max_tokens" not in call_kwargs.kwargs
         assert call_kwargs.kwargs["max_completion_tokens"] == 800
         assert result == "test response"
+
+    def test_base_url_passed_to_client(self):
+        """base_url 指定時、OpenAI クライアントに base_url が渡ることを確認"""
+        config = LLMConfig(
+            provider="openai",
+            model="kimi-k2-turbo-preview",
+            api_key="sk-test",
+            base_url="https://api.moonshot.ai/v1",
+        )
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "test response"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        mock_openai_module = MagicMock()
+        mock_openai_module.OpenAI.return_value = mock_client
+
+        with patch.dict("sys.modules", {"openai": mock_openai_module}):
+            import importlib
+            import md2map.llm.openai_provider as oai_mod
+            importlib.reload(oai_mod)
+            provider = oai_mod.OpenAIProvider(config)
+            result = provider.send_message("system", "user")
+
+        client_kwargs = mock_openai_module.OpenAI.call_args.kwargs
+        assert client_kwargs["base_url"] == "https://api.moonshot.ai/v1"
+        assert client_kwargs["api_key"] == "sk-test"
+        # 互換 API では max_completion_tokens ではなく max_tokens を使う
+        call_kwargs = mock_client.chat.completions.create.call_args
+        assert "max_tokens" in call_kwargs.kwargs
+        assert "max_completion_tokens" not in call_kwargs.kwargs
+        assert call_kwargs.kwargs["max_tokens"] == 800
+        assert result == "test response"
+
+    def test_no_base_url_client_default(self):
+        """base_url 未指定時、OpenAI クライアントに base_url が渡らないことを確認"""
+        config = LLMConfig(provider="openai", model="gpt-4o-mini", api_key="sk-test")
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "test response"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        mock_openai_module = MagicMock()
+        mock_openai_module.OpenAI.return_value = mock_client
+
+        with patch.dict("sys.modules", {"openai": mock_openai_module}):
+            import importlib
+            import md2map.llm.openai_provider as oai_mod
+            importlib.reload(oai_mod)
+            oai_mod.OpenAIProvider(config)
+
+        client_kwargs = mock_openai_module.OpenAI.call_args.kwargs
+        assert "base_url" not in client_kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

OpenAI プロバイダーで接続先 URL（`base_url`）を指定できるようにし、Moonshot AI（Kimi）等の OpenAI 互換 API に接続可能にします。

[#35](https://github.com/elvezjp/md2map/pull/35) の再実装です（`versions/` ディレクトリ廃止後の最新 main をベースに作り直し）。

spec-code-ai-reviewer の [PR #124](https://github.com/elvezjp/spec-code-ai-reviewer/pull/124) で Kimi API 対応（baseUrl 追加）が行われましたが、分割時の AI サマリー生成で使用される md2map 側が base_url 未対応のため、互換 API のキーを持ったまま OpenAI 公式 API に接続してしまい 401 エラーが発生していました。

```
AI summary generation failed for '...': Error code: 401 - Incorrect API key provided: sk-5gRPW***
```

## 変更内容

- **`LLMConfig`**: `base_url` フィールドを追加（`Optional[str]`、デフォルト `None`）
- **`OpenAIProvider`**:
  - `base_url` 指定時にその URL へ接続（未指定時は従来どおり公式 API）
  - 互換 API には `max_completion_tokens` 未対応のものがあるため、`base_url` 指定時は従来の `max_tokens` パラメータで API を呼び出す（spec-code-ai-reviewer の `OpenAIProvider` と同じ方式）
- **`build_llm_config_from_env`**: 環境変数 `OPENAI_BASE_URL` を読み取り、CLI からも互換 API を利用可能に
- **CHANGELOG（日英）**: 既存の `[0.5.0] - Unreleased` セクションに「追加 / Added」として追記（バージョン番号は 0.5.0 のまま変更なし）

## 後方互換性

`base_url` 未指定時の動作は従来と完全に同一です（公式 API + `max_completion_tokens`）。

## テスト

- `base_url` がクライアント生成に渡ること／未指定時は渡らないことを確認するテストを追加
- `base_url` 指定時に `max_tokens`、未指定時に `max_completion_tokens` が使われることを確認
- `OPENAI_BASE_URL` 環境変数の読み取りテストを追加
- 全 141 テストがパス

## 関連

- elvezjp/spec-code-ai-reviewer#124（Kimi API 対応）
- 本 PR マージ後、spec-code-ai-reviewer 側の `_convert_to_md2map_llm_config` に `base_url` の受け渡しを追加する対応が必要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)