### PR TITLE
feat: セクション単位のAI呼び出し（要約・AI分割）を並列実行可能にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `OpenAIProvider` connects to the specified URL when `base_url` is set (defaults to the official OpenAI API when unset)
   - Since some OpenAI-compatible APIs do not support `max_completion_tokens`, the provider falls back to the legacy `max_tokens` parameter when `base_url` is set
   - `build_llm_config_from_env` now reads the `OPENAI_BASE_URL` environment variable, making compatible APIs available from the CLI as well
+- **Concurrent per-section AI calls** (#34): Per-section LLM calls for AI summaries and AI splits can now run in parallel via a thread pool
+  - Added an `ai_concurrency` argument to `MarkdownParser` and an `--ai-concurrency` CLI option (default `1` = sequential, same as before)
+  - Output (order of sections, summaries, and warnings) is guaranteed to match sequential execution
+  - A failure in one section is recorded as a warning for that section and does not affect the processing of other sections
+  - Made the lazy initialization of the LLM provider thread-safe
+
+### Fixed
+
+- **Fixed injected `llm_provider` being ignored when only `summary_mode="ai"` is set**: previously the injected provider was used only with `split_mode="ai"`, and AI-summary-only runs fell back to environment-variable configuration
 
 ### Changed
 

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -15,6 +15,15 @@
   - `OpenAIProvider` が `base_url` 指定時にその URL へ接続（未指定時は従来どおり OpenAI 公式 API）
   - OpenAI 互換 API には `max_completion_tokens` 未対応のものがあるため、`base_url` 指定時は従来の `max_tokens` パラメータで API を呼び出す
   - `build_llm_config_from_env` が環境変数 `OPENAI_BASE_URL` を読み取り、CLI からも互換 API を利用可能に
+- **セクション単位の AI 呼び出しの並列実行**（#34）: AI 要約・AI 分割のセクション単位 LLM 呼び出しをスレッドプールで並列実行可能に
+  - `MarkdownParser` に `ai_concurrency` 引数、CLI に `--ai-concurrency` オプションを追加（デフォルト `1` = 従来どおり逐次実行）
+  - 出力（セクション・要約・警告の順序）は逐次実行時と一致することを保証
+  - 一部セクションの失敗は該当セクションの警告として記録され、他セクションの処理には影響しない
+  - LLM プロバイダーの遅延初期化をスレッドセーフ化
+
+### 修正
+
+- **注入した `llm_provider` が `summary_mode="ai"` 単独では使用されない問題を修正**: 従来は `split_mode="ai"` の場合のみ注入プロバイダーを使用し、AI 要約のみの場合は環境変数フォールバックが使われていた
 
 ### 変更
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ uv run md2map build document.md --dry-run
 | `--section-overrides <JSON>` | None | Per-section split settings override (JSON file path or JSON string) |
 | `--summary-max-chars <N>` | `100` | Maximum character count for rule-based summary |
 | `--summary-mode <MODE>` | `text` | Summary generation mode (`text`: rule-based / `ai`: LLM summary) |
+| `--ai-concurrency <N>` | `1` | Concurrency for per-section AI calls (summary / AI split) (`1`: sequential) |
 | `--verbose` | false | Output detailed logs |
 | `--dry-run` | false | Preview only, no file generation |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -194,6 +194,7 @@ uv run md2map build document.md --dry-run
 | `--section-overrides <JSON>` | なし | セクション単位の分割設定オーバーライド（JSONファイルパスまたはJSON文字列） |
 | `--summary-max-chars <N>` | `100` | ルールベースサマリーの文字数上限 |
 | `--summary-mode <MODE>` | `text` | サマリー生成モード（`text`: ルールベース / `ai`: LLM要約） |
+| `--ai-concurrency <N>` | `1` | セクション単位のAI呼び出し（要約・AI分割）の並列度（`1`: 逐次実行） |
 | `--verbose` | false | 詳細ログを出力 |
 | `--dry-run` | false | ファイル生成せずプレビューのみ |
 

--- a/md2map/cli.py
+++ b/md2map/cli.py
@@ -112,6 +112,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         choices=["text", "ai"],
         help="サマリー生成モード（text: ルールベース, ai: LLM要約）",
     )
+    build_parser.add_argument(
+        "--ai-concurrency",
+        type=int,
+        default=1,
+        help="セクション単位の AI 呼び出し（要約・AI分割）の並列度（デフォルト: 1 = 逐次実行）",
+    )
 
     # headings サブコマンド
     headings_parser = subparsers.add_parser(
@@ -212,6 +218,7 @@ def cmd_build(args: argparse.Namespace) -> int:
             section_overrides=section_overrides,
             summary_max_chars=args.summary_max_chars,
             summary_mode=args.summary_mode,
+            ai_concurrency=args.ai_concurrency,
         )
     except (ValueError, RuntimeError) as exc:
         logger.error(str(exc))

--- a/md2map/parsers/markdown_parser.py
+++ b/md2map/parsers/markdown_parser.py
@@ -3,6 +3,8 @@
 import json
 import math
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
@@ -92,6 +94,7 @@ class MarkdownParser(BaseParser):
         section_overrides: Optional[List[Dict[str, any]]] = None,
         summary_max_chars: int = 100,
         summary_mode: str = "text",
+        ai_concurrency: int = 1,
     ) -> None:
         if split_mode not in {"heading", "nlp", "ai"}:
             raise ValueError(f"Invalid split_mode: {split_mode}")
@@ -100,19 +103,22 @@ class MarkdownParser(BaseParser):
         self._nlp_tokenizer = None
         self._llm_provider: Optional["BaseLLMProvider"] = None
         self._llm_config = llm_config
+        self._llm_init_lock = threading.Lock()
         if split_mode == "nlp":
             self._ensure_nlp_tokenizer()
-        if split_mode == "ai":
-            if llm_provider is not None:
-                self._llm_provider = llm_provider
-            else:
-                self._ensure_llm_provider()
+        # 注入された llm_provider は summary_mode="ai" のみの場合でも使用する
+        if llm_provider is not None:
+            self._llm_provider = llm_provider
+        elif split_mode == "ai":
+            self._ensure_llm_provider()
         self.split_mode = split_mode
         self.split_threshold = max(1, split_threshold)
         self.max_subsections = max(1, max_subsections)
         self._ai_prompt_extra_notes = ai_prompt_extra_notes
         self.summary_max_chars = max(1, summary_max_chars)
         self.summary_mode = summary_mode
+        # セクション単位の AI 呼び出し（要約・AI分割）の並列度。1 で従来の逐次実行
+        self.ai_concurrency = max(1, ai_concurrency)
         # セクション単位のオーバーライドマップ（start_line → 設定 dict）
         self._override_map: Dict[int, Dict[str, any]] = {}
         if section_overrides:
@@ -120,17 +126,20 @@ class MarkdownParser(BaseParser):
                 self._override_map[o["start_line"]] = o
 
     def _ensure_llm_provider(self) -> None:
-        """LLM provider が未初期化なら初期化する（遅延初期化）"""
+        """LLM provider が未初期化なら初期化する（遅延初期化・スレッドセーフ）"""
         if self._llm_provider is not None:
             return
-        if self._llm_config is not None:
-            from md2map.llm.factory import get_llm_provider
-            self._llm_provider = get_llm_provider(self._llm_config)
-        else:
-            # 後方互換: 環境変数からフォールバック
-            from md2map.llm.factory import build_llm_config_from_env, get_llm_provider
-            fallback_config = build_llm_config_from_env(provider="bedrock")
-            self._llm_provider = get_llm_provider(fallback_config)
+        with self._llm_init_lock:
+            if self._llm_provider is not None:
+                return
+            if self._llm_config is not None:
+                from md2map.llm.factory import get_llm_provider
+                self._llm_provider = get_llm_provider(self._llm_config)
+            else:
+                # 後方互換: 環境変数からフォールバック
+                from md2map.llm.factory import build_llm_config_from_env, get_llm_provider
+                fallback_config = build_llm_config_from_env(provider="bedrock")
+                self._llm_provider = get_llm_provider(fallback_config)
 
     def _ensure_nlp_tokenizer(self) -> None:
         """NLP tokenizer が未初期化なら初期化する（遅延初期化）"""
@@ -264,9 +273,8 @@ class MarkdownParser(BaseParser):
         if self.split_mode != "heading" or has_non_heading_override:
             sections = self._refine_sections(sections, lines)
 
-        # 各セクションの追加情報を抽出
-        for section in sections:
-            self._extract_section_info(section, lines)
+        # 各セクションの追加情報を抽出（AI要約は ai_concurrency に応じて並列実行）
+        self._extract_section_infos(sections, lines)
 
         return sections, warnings
 
@@ -446,12 +454,49 @@ class MarkdownParser(BaseParser):
         self._build_hierarchy(filtered)
         return filtered
 
-    def _extract_section_info(self, section: Section, lines: List[str]) -> None:
+    def _extract_section_infos(
+        self, sections: List[Section], lines: List[str]
+    ) -> None:
+        """全セクションの追加情報を抽出する
+
+        AI要約が必要なセクションがあり ai_concurrency が 2 以上の場合、
+        セクション単位でスレッドプールにより並列実行する。
+        警告はセクション順に追記し、逐次実行時と同一の順序を保証する。
+        """
+        needs_ai = any(
+            self._resolve_settings(s)["summary_mode"] == "ai" for s in sections
+        )
+        if self.ai_concurrency <= 1 or len(sections) <= 1 or not needs_ai:
+            for section in sections:
+                self._extract_section_info(section, lines)
+            return
+
+        # 並列実行前にプロバイダーを初期化（遅延初期化の競合を回避）
+        self._ensure_llm_provider()
+
+        def run(section: Section) -> List[str]:
+            buffer: List[str] = []
+            self._extract_section_info(section, lines, warnings_sink=buffer)
+            return buffer
+
+        max_workers = min(self.ai_concurrency, len(sections))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            buffers = list(executor.map(run, sections))
+        for buffer in buffers:
+            self._warnings.extend(buffer)
+
+    def _extract_section_info(
+        self,
+        section: Section,
+        lines: List[str],
+        warnings_sink: Optional[List[str]] = None,
+    ) -> None:
         """セクションの追加情報（要約、キーワード、リンク）を抽出する
 
         Args:
             section: セクション（変更される）
             lines: ファイルの行リスト
+            warnings_sink: 警告の追記先（未指定時は self._warnings）
         """
         settings = self._resolve_settings(section)
         summary_mode = settings["summary_mode"]
@@ -465,7 +510,9 @@ class MarkdownParser(BaseParser):
         skip_first = self.HEADING_PATTERN.match(section_lines[0].rstrip()) is not None
 
         if summary_mode == "ai":
-            section.summary = self._generate_ai_summary(section, section_text, max_chars)
+            section.summary = self._generate_ai_summary(
+                section, section_text, max_chars, warnings_sink=warnings_sink
+            )
         else:
             section.summary = self._extract_summary(
                 section_lines, skip_first_line=skip_first, max_chars=max_chars
@@ -554,7 +601,11 @@ class MarkdownParser(BaseParser):
         )
 
     def _generate_ai_summary(
-        self, section: Section, section_text: str, max_chars: int
+        self,
+        section: Section,
+        section_text: str,
+        max_chars: int,
+        warnings_sink: Optional[List[str]] = None,
     ) -> Optional[str]:
         """LLMを使用してセクションの要約を生成する
 
@@ -562,6 +613,7 @@ class MarkdownParser(BaseParser):
             section: セクション
             section_text: セクションのテキスト
             max_chars: 要約の最大文字数
+            warnings_sink: 警告の追記先（未指定時は self._warnings）
 
         Returns:
             AI生成の要約文字列、失敗時は None
@@ -582,7 +634,8 @@ class MarkdownParser(BaseParser):
         except Exception as exc:
             warning_msg = f"AI summary generation failed for '{section.title}': {exc}"
             logger.warning(warning_msg)
-            self._warnings.append(warning_msg)
+            sink = self._warnings if warnings_sink is None else warnings_sink
+            sink.append(warning_msg)
             return None
 
     def _count_words(self, text: str) -> int:
@@ -632,11 +685,91 @@ class MarkdownParser(BaseParser):
 
         return own_start, own_end
 
+    def _ai_split_args(
+        self, section: Section, sections: List[Section], lines: List[str]
+    ) -> Optional[Tuple[int, int, int, str]]:
+        """セクションが AI 分割対象なら _select_chunks_ai の引数を返す
+
+        _refine_sections() の AI 分岐と同じ判定条件を使用する。
+        対象外の場合は None を返す。
+
+        Returns:
+            (own_start, own_end, target_parts, extra_notes) または None
+        """
+        settings = self._resolve_settings(section)
+        if settings["split_mode"] != "ai":
+            return None
+        max_subs = max(1, settings["max_subsections"])
+        if max_subs <= 1:
+            return None
+        own_start, own_end = self._get_own_content_range(section, sections)
+        if own_start > own_end:
+            return None
+        own_text = "".join(lines[own_start - 1 : own_end])
+        total_count = self._count_words(own_text)
+        threshold = max(1, settings["split_threshold"])
+        if total_count < threshold:
+            return None
+        if own_end - own_start + 1 < 2:
+            return None
+        target_parts = min(max_subs, max(2, math.ceil(total_count / threshold)))
+        return own_start, own_end, target_parts, settings.get("ai_prompt_extra_notes", "")
+
+    def _precompute_ai_chunks(
+        self, sections: List[Section], lines: List[str]
+    ) -> Dict[int, List[Tuple[int, int]]]:
+        """AI 分割対象セクションの _select_chunks_ai 結果を並列に先行計算する
+
+        ai_concurrency が 1 の場合や対象が 1 件以下の場合は空の辞書を返し、
+        呼び出し元（_refine_sections）の逐次処理にフォールバックする。
+        警告はセクション順に追記し、逐次実行時と同一の順序を保証する。
+
+        Returns:
+            セクションのインデックス → line_ranges の辞書
+        """
+        if self.ai_concurrency <= 1:
+            return {}
+
+        tasks: List[Tuple[int, Section, Tuple[int, int, int, str]]] = []
+        for index, section in enumerate(sections):
+            args = self._ai_split_args(section, sections, lines)
+            if args is not None:
+                tasks.append((index, section, args))
+        if len(tasks) <= 1:
+            return {}
+
+        # 並列実行前にプロバイダーを初期化（遅延初期化の競合を回避）
+        self._ensure_llm_provider()
+
+        def run(
+            task: Tuple[int, Section, Tuple[int, int, int, str]]
+        ) -> Tuple[List[Tuple[int, int]], List[str]]:
+            _, section, (own_start, own_end, target_parts, extra_notes) = task
+            buffer: List[str] = []
+            line_ranges, _ = self._select_chunks_ai(
+                section, lines, own_start, own_end, target_parts,
+                extra_notes=extra_notes, warnings_sink=buffer,
+            )
+            return line_ranges, buffer
+
+        max_workers = min(self.ai_concurrency, len(tasks))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            outputs = list(executor.map(run, tasks))
+
+        results: Dict[int, List[Tuple[int, int]]] = {}
+        for (index, _, _), (line_ranges, buffer) in zip(tasks, outputs, strict=True):
+            results[index] = line_ranges
+            self._warnings.extend(buffer)
+        return results
+
     def _refine_sections(self, sections: List[Section], lines: List[str]) -> List[Section]:
         """セクションを再分割してサブスプリットを挿入する"""
         refined: List[Section] = []
 
-        for section in sections:
+        # AI 分割対象の結果を先行計算（ai_concurrency >= 2 のとき並列実行）
+        ai_chunk_cache = self._precompute_ai_chunks(sections, lines)
+
+        for index, section in enumerate(sections):
             # セクションごとに設定を解決
             settings = self._resolve_settings(section)
             split_mode = settings["split_mode"]
@@ -675,10 +808,14 @@ class MarkdownParser(BaseParser):
                     max(2, math.ceil(total_count / threshold)),
                 )
 
-                line_ranges, _ = self._select_chunks_ai(
-                    section, lines, own_start, own_end, target_parts,
-                    extra_notes=extra_notes,
-                )
+                cached = ai_chunk_cache.get(index)
+                if cached is not None:
+                    line_ranges = cached
+                else:
+                    line_ranges, _ = self._select_chunks_ai(
+                        section, lines, own_start, own_end, target_parts,
+                        extra_notes=extra_notes,
+                    )
                 if not line_ranges:
                     line_ranges = self._chunk_lines_by_threshold(
                         lines, own_start, own_end, total_count, target_parts
@@ -892,6 +1029,7 @@ class MarkdownParser(BaseParser):
         own_end: int,
         target_parts: int,
         extra_notes: str = "",
+        warnings_sink: Optional[List[str]] = None,
     ) -> Tuple[List[Tuple[int, int]], None]:
         """AI（LLMプロバイダー）で行番号ベースのグループ分けを取得する
 
@@ -922,7 +1060,8 @@ class MarkdownParser(BaseParser):
         except Exception as exc:
             warning_msg = f"AI API call failed: {exc}"
             logger.warning(warning_msg)
-            self._warnings.append(warning_msg)
+            sink = self._warnings if warnings_sink is None else warnings_sink
+            sink.append(warning_msg)
             return [], None
 
         # LLM が ```json ... ``` で囲んで返す場合に対応

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -726,7 +726,9 @@ class ThreadSafeMockProvider(BaseLLMProvider):
 
 
 def _write_temp_md(content: str) -> str:
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", delete=False, encoding="utf-8"
+    ) as f:
         f.write(content)
         return f.name
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -699,3 +699,223 @@ class TestAIPromptCustomization:
         prompt = parser._build_ai_system_prompt()
         assert "title" not in prompt
         assert "タイトル" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# AI 呼び出し並列実行テスト（Issue #34）
+# ---------------------------------------------------------------------------
+
+
+class ThreadSafeMockProvider(BaseLLMProvider):
+    """並列実行テスト用の LLM プロバイダー
+
+    respond(system_prompt, user_message) の結果を返す。例外送出も可能。
+    """
+
+    def __init__(self, respond):
+        import threading
+
+        self.respond = respond
+        self.calls: list[tuple[str, str]] = []
+        self._lock = threading.Lock()
+
+    def send_message(self, system_prompt: str, user_message: str) -> str:
+        with self._lock:
+            self.calls.append((system_prompt, user_message))
+        return self.respond(system_prompt, user_message)
+
+
+def _write_temp_md(content: str) -> str:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(content)
+        return f.name
+
+
+def _multi_section_content(num_sections: int = 4) -> str:
+    """複数セクションのテスト用マークダウンを生成する"""
+    content = ""
+    for i in range(num_sections):
+        content += f"# Section{i + 1}\n\n"
+        content += "内容のテキストです。" * 20 + "\n\n"
+    return content
+
+
+class TestAIConcurrency:
+    """ai_concurrency 設定のテスト"""
+
+    def test_default_is_sequential(self):
+        """デフォルトは 1（逐次実行）"""
+        parser = MarkdownParser()
+        assert parser.ai_concurrency == 1
+
+    def test_concurrency_clamped_to_one(self):
+        """0 以下は 1 に丸められる"""
+        parser = MarkdownParser(ai_concurrency=0)
+        assert parser.ai_concurrency == 1
+        parser = MarkdownParser(ai_concurrency=-5)
+        assert parser.ai_concurrency == 1
+
+    def test_concurrency_stored(self):
+        parser = MarkdownParser(ai_concurrency=4)
+        assert parser.ai_concurrency == 4
+
+
+class TestParallelAISummary:
+    """AI要約の並列実行テスト"""
+
+    def _run_parse(self, concurrency: int, respond):
+        provider = ThreadSafeMockProvider(respond)
+        temp_path = _write_temp_md(_multi_section_content(4))
+        try:
+            parser = MarkdownParser(
+                summary_mode="ai",
+                llm_provider=provider,
+                ai_concurrency=concurrency,
+            )
+            sections, warnings = parser.parse(temp_path)
+            return sections, warnings, provider
+        finally:
+            os.unlink(temp_path)
+
+    def test_parallel_summaries_match_sequential(self):
+        """並列実行の要約・警告が逐次実行と一致する"""
+
+        def respond(system, user):
+            # セクション名をエコーして呼び出しを区別可能にする
+            for i in range(1, 5):
+                if f"Section{i}" in user:
+                    return f"要約{i}"
+            return "要約"
+
+        seq_sections, seq_warnings, _ = self._run_parse(1, respond)
+        par_sections, par_warnings, par_provider = self._run_parse(4, respond)
+
+        assert [s.summary for s in par_sections] == [
+            s.summary for s in seq_sections
+        ]
+        assert par_warnings == seq_warnings
+        assert len(par_provider.calls) == 4
+
+    def test_partial_failure_does_not_affect_others(self):
+        """一部セクションの失敗が他セクションに影響しない"""
+
+        def respond(system, user):
+            if "Section2" in user:
+                raise RuntimeError("simulated failure")
+            return "要約OK"
+
+        sections, warnings, _ = self._run_parse(4, respond)
+
+        summaries = [s.summary for s in sections]
+        assert summaries[0] == "要約OK"
+        assert summaries[1] is None  # 失敗したセクション
+        assert summaries[2] == "要約OK"
+        assert summaries[3] == "要約OK"
+        assert len(warnings) == 1
+        assert "Section2" in warnings[0]
+
+    def test_warnings_preserve_section_order(self):
+        """並列実行でも警告がセクション順に並ぶ"""
+        import time
+
+        def respond(system, user):
+            # 逆順で完了するように遅延を入れる
+            if "Section1" in user:
+                time.sleep(0.05)
+                raise RuntimeError("fail-1")
+            if "Section3" in user:
+                raise RuntimeError("fail-3")
+            return "要約OK"
+
+        sections, warnings, _ = self._run_parse(4, respond)
+
+        assert len(warnings) == 2
+        assert "Section1" in warnings[0]
+        assert "Section3" in warnings[1]
+
+    def test_text_mode_not_parallelized(self):
+        """summary_mode=text では LLM 呼び出しなし（並列化パスに入らない）"""
+        provider = ThreadSafeMockProvider(lambda s, u: "unused")
+        temp_path = _write_temp_md(_multi_section_content(3))
+        try:
+            parser = MarkdownParser(
+                summary_mode="text",
+                llm_provider=provider,
+                ai_concurrency=4,
+            )
+            sections, warnings = parser.parse(temp_path)
+            assert len(provider.calls) == 0
+            assert all(s.summary for s in sections)
+        finally:
+            os.unlink(temp_path)
+
+
+class TestParallelAISplit:
+    """AI分割の並列実行テスト"""
+
+    def _two_section_content(self) -> str:
+        """同一行数の 2 セクション（own content 9 行ずつ）を生成する"""
+        section = "".join(
+            "Paragraph " + str(i + 1) + " content. " * 50 + "\n\n"
+            for i in range(4)
+        )
+        return f"# First\n\n{section}# Second\n\n{section}"
+
+    def _run_split(self, concurrency: int, respond):
+        provider = ThreadSafeMockProvider(respond)
+        temp_path = _write_temp_md(self._two_section_content())
+        try:
+            parser = MarkdownParser(
+                split_mode="ai",
+                split_threshold=50,
+                llm_provider=provider,
+                ai_concurrency=concurrency,
+            )
+            sections, warnings = parser.parse(temp_path)
+            return sections, warnings, provider
+        finally:
+            os.unlink(temp_path)
+
+    def test_parallel_split_matches_sequential(self):
+        """並列実行の分割結果が逐次実行と一致する"""
+        ai_response = json.dumps([
+            {"start_line": 1, "end_line": 5},
+            {"start_line": 6, "end_line": 9},
+        ])
+
+        seq_sections, seq_warnings, _ = self._run_split(1, lambda s, u: ai_response)
+        par_sections, par_warnings, par_provider = self._run_split(
+            4, lambda s, u: ai_response
+        )
+
+        assert len(par_provider.calls) == 2
+
+        def describe(sections):
+            return [
+                (s.title, s.is_subsplit, s.subsplit_title, s.start_line, s.end_line)
+                for s in sections
+            ]
+
+        assert describe(par_sections) == describe(seq_sections)
+        assert par_warnings == seq_warnings
+
+        # 各親セクションに 2 つずつ仮想セクションが生成される
+        virtual = [s for s in par_sections if s.is_subsplit]
+        assert len(virtual) == 4
+
+    def test_parallel_split_failure_falls_back(self):
+        """並列実行でも AI 呼び出し失敗時は閾値ベースにフォールバックする"""
+
+        def respond(system, user):
+            raise RuntimeError("simulated API failure")
+
+        sections, warnings, _ = self._run_split(4, respond)
+
+        # フォールバックで仮想セクションが生成される
+        virtual = [s for s in sections if s.is_subsplit]
+        assert len(virtual) >= 2
+        for vs in virtual:
+            assert "ai threshold split" in vs.note
+        # 失敗ごとに警告が記録される
+        assert len(warnings) == 2
+        assert all("AI API call failed" in w for w in warnings)


### PR DESCRIPTION
## 概要

[#34](https://github.com/elvezjp/md2map/issues/34) の対応です。AI モードでセクションごとに直列実行されていた LLM 呼び出し（AI要約・AI分割）を、スレッドプールで並列実行できるようにします。

**[#38](https://github.com/elvezjp/md2map/pull/38) の再作成です**（#38 はベースブランチ（#37）のマージ・削除に伴い自動クローズされたため、main ベースで作り直し。変更内容は #38 と同一 + main とのマージコミットのみ）。

Issue に記載のリトライ（#33）は本 PR の対象外です。

## 変更内容

- **`MarkdownParser`**: `ai_concurrency` 引数を追加（デフォルト `1` = 従来どおり逐次実行、完全互換）
- **CLI**: `--ai-concurrency` オプションを追加
- **AI要約**: `parse()` 内のセクションループを `_extract_section_infos()` に集約し、AI要約が必要かつ `ai_concurrency >= 2` の場合に `ThreadPoolExecutor` で並列実行
- **AI分割**: `_precompute_ai_chunks()` で分割対象セクションの `_select_chunks_ai()` 結果を先行して並列計算し、`_refine_sections()` の既存ループはキャッシュを参照（対象判定は `_ai_split_args()` に切り出し、既存分岐と同一条件）
- **警告のスレッドセーフ化と順序保証**: 並列実行時はタスクごとのバッファに警告を収集し、セクション順に `self._warnings` へ追記。逐次実行時と同一の出力順序を保証
- **プロバイダー遅延初期化のスレッドセーフ化**: `_ensure_llm_provider()` をロックで保護し、並列実行前に事前初期化
- **修正**: `summary_mode="ai"` 単独（`split_mode="heading"`）の場合に、注入した `llm_provider` が無視され環境変数フォールバックが使われていた問題を修正
- README(日英)の主要オプション表と CHANGELOG(日英)の `[0.5.0] - Unreleased` に追記

## 受け入れ条件の確認

- [x] 複数セクションの AI 要約・AI分割が並列実行され、出力が直列実行時と一致する（テストで直列/並列の結果を比較）
- [x] 並列度を設定で変更でき、1 に設定すると従来と同じ逐次実行になる
- [x] 一部セクションの失敗が他セクションの処理に影響しない（テストあり）

## テスト

- 並列/逐次の結果一致（要約・AI分割・警告順序）、部分失敗の分離、`ai_concurrency` のバリデーションなど9件を追加
- 全 150 テストがパス（main マージ後にも確認済み）

## 関連

- Closes #34（リトライ #33 は未対応のまま）
- Supersedes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)