### PR TITLE
feat: 推論モデルの思考量（reasoning_effort）指定に対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `OpenAIProvider` connects to the specified URL when `base_url` is set (defaults to the official OpenAI API when unset)
   - Since some OpenAI-compatible APIs do not support `max_completion_tokens`, the provider falls back to the legacy `max_tokens` parameter when `base_url` is set
   - `build_llm_config_from_env` now reads the `OPENAI_BASE_URL` environment variable, making compatible APIs available from the CLI as well
+- **Reasoning effort support for reasoning models**: Added a `reasoning_effort` field to `LLMConfig`
+  - `OpenAIProvider` sends `reasoning_effort` to the API only when specified (when unset, the parameter is not sent and the model's default thinking effort applies, same as before)
+  - Allowed values are model-dependent, so they are passed through to the API without validation (e.g. Kimi K3 accepts low/high/max)
+  - Added an `--ai-reasoning-effort` CLI option, with fallback to the `MD2MAP_REASONING_EFFORT` environment variable
 - **Concurrent per-section AI calls** (#34): Per-section LLM calls for AI summaries and AI splits can now run in parallel via a thread pool
   - Added an `ai_concurrency` argument to `MarkdownParser` and an `--ai-concurrency` CLI option (default `1` = sequential, same as before)
   - Output (order of sections, summaries, and warnings) is guaranteed to match sequential execution

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -15,6 +15,10 @@
   - `OpenAIProvider` が `base_url` 指定時にその URL へ接続（未指定時は従来どおり OpenAI 公式 API）
   - OpenAI 互換 API には `max_completion_tokens` 未対応のものがあるため、`base_url` 指定時は従来の `max_tokens` パラメータで API を呼び出す
   - `build_llm_config_from_env` が環境変数 `OPENAI_BASE_URL` を読み取り、CLI からも互換 API を利用可能に
+- **推論モデルの思考量（reasoning_effort）指定に対応**: `LLMConfig` に `reasoning_effort` フィールドを追加
+  - `OpenAIProvider` が指定時のみ `reasoning_effort` を API に送信（未指定時は従来どおり送信せず、各モデルのデフォルト思考量で動作）
+  - 設定可能な値はモデル依存のため検証せず API へパススルー（例: Kimi K3 は low/high/max）
+  - CLI に `--ai-reasoning-effort` オプションを追加。環境変数 `MD2MAP_REASONING_EFFORT` にもフォールバック
 - **セクション単位の AI 呼び出しの並列実行**（#34）: AI 要約・AI 分割のセクション単位 LLM 呼び出しをスレッドプールで並列実行可能に
   - `MarkdownParser` に `ai_concurrency` 引数、CLI に `--ai-concurrency` オプションを追加（デフォルト `1` = 従来どおり逐次実行）
   - 出力（セクション・要約・警告の順序）は逐次実行時と一致することを保証

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ uv run md2map build document.md --dry-run
 | `--summary-max-chars <N>` | `100` | Maximum character count for rule-based summary |
 | `--summary-mode <MODE>` | `text` | Summary generation mode (`text`: rule-based / `ai`: LLM summary) |
 | `--ai-concurrency <N>` | `1` | Concurrency for per-section AI calls (summary / AI split) (`1`: sequential) |
+| `--ai-reasoning-effort <LEVEL>` | none | Thinking effort for reasoning models (OpenAI provider, e.g. `low`/`medium`/`high`/`max`; allowed values are model-dependent; not sent when unset) |
 | `--verbose` | false | Output detailed logs |
 | `--dry-run` | false | Preview only, no file generation |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -195,6 +195,7 @@ uv run md2map build document.md --dry-run
 | `--summary-max-chars <N>` | `100` | ルールベースサマリーの文字数上限 |
 | `--summary-mode <MODE>` | `text` | サマリー生成モード（`text`: ルールベース / `ai`: LLM要約） |
 | `--ai-concurrency <N>` | `1` | セクション単位のAI呼び出し（要約・AI分割）の並列度（`1`: 逐次実行） |
+| `--ai-reasoning-effort <LEVEL>` | なし | 推論モデルの思考量（OpenAI用、例: `low`/`medium`/`high`/`max`。設定可能な値はモデル依存。未指定時は送信しない） |
 | `--verbose` | false | 詳細ログを出力 |
 | `--dry-run` | false | ファイル生成せずプレビューのみ |
 

--- a/md2map/cli.py
+++ b/md2map/cli.py
@@ -118,6 +118,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=1,
         help="セクション単位の AI 呼び出し（要約・AI分割）の並列度（デフォルト: 1 = 逐次実行）",
     )
+    build_parser.add_argument(
+        "--ai-reasoning-effort",
+        default=None,
+        help="推論モデルの思考量（OpenAI 用、例: low / medium / high / max。"
+        "設定可能な値はモデル依存。未指定時は送信しない）",
+    )
 
     # headings サブコマンド
     headings_parser = subparsers.add_parser(
@@ -204,6 +210,7 @@ def cmd_build(args: argparse.Namespace) -> int:
                 provider=args.ai_provider,
                 model=args.ai_model,
                 region=args.ai_region,
+                reasoning_effort=args.ai_reasoning_effort,
             )
         except (ValueError, RuntimeError) as exc:
             logger.error(str(exc))

--- a/md2map/llm/config.py
+++ b/md2map/llm/config.py
@@ -13,6 +13,8 @@ class LLMConfig:
         model: モデルID
         api_key: API キー（Anthropic / OpenAI 用）
         base_url: OpenAI 互換 API（Moonshot AI 等）の接続先 URL（OpenAI 用、未指定時は公式 API）
+        reasoning_effort: 推論モデルの思考量（OpenAI 用、未指定時は送信しない。
+            設定可能な値はモデル依存のため検証せず API へパススルー）
         access_key_id: アクセスキーID（Bedrock 用）
         secret_access_key: シークレットアクセスキー（Bedrock 用）
         region: リージョン（Bedrock 用）
@@ -23,6 +25,7 @@ class LLMConfig:
     model: str
     api_key: Optional[str] = None
     base_url: Optional[str] = None
+    reasoning_effort: Optional[str] = None
     access_key_id: Optional[str] = None
     secret_access_key: Optional[str] = None
     region: Optional[str] = None

--- a/md2map/llm/factory.py
+++ b/md2map/llm/factory.py
@@ -38,6 +38,7 @@ def build_llm_config_from_env(
     provider: str = "bedrock",
     model: Optional[str] = None,
     region: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> LLMConfig:
     """環境変数から LLMConfig を構築する（CLI / 後方互換用）
 
@@ -45,6 +46,8 @@ def build_llm_config_from_env(
         provider: プロバイダー名
         model: モデルID（未指定時は環境変数またはデフォルト値）
         region: リージョン（Bedrock 用）
+        reasoning_effort: 推論モデルの思考量（OpenAI 用、未指定時は環境変数
+            MD2MAP_REASONING_EFFORT にフォールバック）
 
     Returns:
         LLMConfig インスタンス
@@ -69,6 +72,8 @@ def build_llm_config_from_env(
             model=resolved_model,
             api_key=api_key,
             base_url=os.getenv("OPENAI_BASE_URL"),
+            reasoning_effort=reasoning_effort
+            or os.getenv("MD2MAP_REASONING_EFFORT"),
         )
 
     elif provider == "anthropic":

--- a/md2map/llm/openai_provider.py
+++ b/md2map/llm/openai_provider.py
@@ -8,6 +8,7 @@ class OpenAIProvider(BaseLLMProvider):
     """OpenAI API を使用する LLM プロバイダー
 
     base_url を指定した場合は OpenAI 互換 API（Moonshot AI 等）に接続する。
+    reasoning_effort を指定した場合は推論モデルの思考量として送信する。
     """
 
     def __init__(self, config: LLMConfig) -> None:
@@ -22,6 +23,7 @@ class OpenAIProvider(BaseLLMProvider):
         self._model = config.model
         self._max_tokens = config.max_tokens
         self._base_url = config.base_url
+        self._reasoning_effort = config.reasoning_effort
         if config.base_url:
             self._client = OpenAI(api_key=config.api_key, base_url=config.base_url)
         else:
@@ -32,6 +34,11 @@ class OpenAIProvider(BaseLLMProvider):
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_message},
         ]
+        # reasoning_effort は指定時のみ送信する
+        # （非推論モデルはパラメータ非対応のため、未指定なら付けない）
+        extra_kwargs = {}
+        if self._reasoning_effort:
+            extra_kwargs["reasoning_effort"] = self._reasoning_effort
         # OpenAI 互換 API には max_completion_tokens 未対応のものがあるため、
         # base_url 指定時は従来の max_tokens パラメータを使用する
         if self._base_url:
@@ -39,12 +46,14 @@ class OpenAIProvider(BaseLLMProvider):
                 model=self._model,
                 messages=messages,
                 max_tokens=self._max_tokens,
+                **extra_kwargs,
             )
         else:
             response = self._client.chat.completions.create(
                 model=self._model,
                 messages=messages,
                 max_completion_tokens=self._max_tokens,
+                **extra_kwargs,
             )
         if not response.choices or not response.choices[0].message.content:
             raise RuntimeError("OpenAI API returned empty response")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -70,6 +70,19 @@ class TestLLMConfig:
         )
         assert config.base_url == "https://api.moonshot.ai/v1"
 
+    def test_reasoning_effort_default_none(self):
+        config = LLMConfig(provider="openai", model="gpt-4o-mini")
+        assert config.reasoning_effort is None
+
+    def test_create_config_with_reasoning_effort(self):
+        config = LLMConfig(
+            provider="openai",
+            model="kimi-k3",
+            api_key="sk-test",
+            reasoning_effort="low",
+        )
+        assert config.reasoning_effort == "low"
+
 
 # ---------------------------------------------------------------------------
 # ファクトリ関数テスト
@@ -145,6 +158,27 @@ class TestBuildLLMConfigFromEnv:
     def test_openai_base_url_default_none(self):
         config = build_llm_config_from_env(provider="openai")
         assert config.base_url is None
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env-key"}, clear=True)
+    def test_openai_reasoning_effort_explicit(self):
+        config = build_llm_config_from_env(
+            provider="openai", reasoning_effort="low"
+        )
+        assert config.reasoning_effort == "low"
+
+    @patch.dict(
+        os.environ,
+        {"OPENAI_API_KEY": "sk-env-key", "MD2MAP_REASONING_EFFORT": "high"},
+        clear=True,
+    )
+    def test_openai_reasoning_effort_from_env(self):
+        config = build_llm_config_from_env(provider="openai")
+        assert config.reasoning_effort == "high"
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env-key"}, clear=True)
+    def test_openai_reasoning_effort_default_none(self):
+        config = build_llm_config_from_env(provider="openai")
+        assert config.reasoning_effort is None
 
     @patch.dict(os.environ, {}, clear=True)
     def test_openai_missing_key_raises(self):
@@ -294,6 +328,60 @@ class TestOpenAIProviderAPICall:
 
         client_kwargs = mock_openai_module.OpenAI.call_args.kwargs
         assert "base_url" not in client_kwargs
+
+    def _send_with_mock(self, config: LLMConfig) -> dict:
+        """モックしたクライアントで send_message し、API 呼び出しの kwargs を返す"""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "test response"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        mock_openai_module = MagicMock()
+        mock_openai_module.OpenAI.return_value = mock_client
+
+        with patch.dict("sys.modules", {"openai": mock_openai_module}):
+            import importlib
+            import md2map.llm.openai_provider as oai_mod
+            importlib.reload(oai_mod)
+            provider = oai_mod.OpenAIProvider(config)
+            provider.send_message("system", "user")
+
+        return mock_client.chat.completions.create.call_args.kwargs
+
+    def test_reasoning_effort_sent_with_base_url(self):
+        """reasoning_effort 指定時、互換 API（base_url あり）でも送信される"""
+        kwargs = self._send_with_mock(
+            LLMConfig(
+                provider="openai",
+                model="kimi-k3",
+                api_key="sk-test",
+                base_url="https://api.moonshot.ai/v1",
+                reasoning_effort="low",
+            )
+        )
+        assert kwargs["reasoning_effort"] == "low"
+        assert kwargs["max_tokens"] == 800
+
+    def test_reasoning_effort_sent_without_base_url(self):
+        """reasoning_effort 指定時、公式 API（base_url なし）でも送信される"""
+        kwargs = self._send_with_mock(
+            LLMConfig(
+                provider="openai",
+                model="gpt-5.2",
+                api_key="sk-test",
+                reasoning_effort="medium",
+            )
+        )
+        assert kwargs["reasoning_effort"] == "medium"
+        assert kwargs["max_completion_tokens"] == 800
+
+    def test_reasoning_effort_omitted_when_unset(self):
+        """reasoning_effort 未指定時は送信されない（従来動作）"""
+        kwargs = self._send_with_mock(
+            LLMConfig(provider="openai", model="gpt-4o-mini", api_key="sk-test")
+        )
+        assert "reasoning_effort" not in kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

推論モデルの思考量を制御する `reasoning_effort` を `LLMConfig` / CLI から指定できるようにします。

利用元の spec-code-ai-reviewer での測定（Kimi K3・一括レビュー）では、**low 指定でデフォルト（max）の約4.1倍高速、検出品質は同等**でした。分割サマリー等の短文生成用途では特に効果が見込めます。

| effort | 平均時間 | 出力トークン |
|---|---|---|
| low | 約49秒 | 1,673 |
| high | 約95秒 | 3,450 |
| max（デフォルト） | 約202秒 | 7,353 |

## 変更内容

- **`LLMConfig`**: `reasoning_effort` フィールドを追加（`Optional[str]`、デフォルト `None`）
- **`OpenAIProvider`**: 指定時のみ `reasoning_effort` を API に送信。**未指定時はパラメータ自体を送らず**、各モデルのデフォルト思考量で動作（完全互換）。base_url あり／なし両方の経路に対応
- **設定可能な値はモデル依存**（Kimi K3: low/high/max、OpenAI: モデルごとに none/minimal/low/medium/high/xhigh/max のサブセット）のため、検証せず API へパススルー。不正値は API エラーとして呼び出し元に伝播
- **CLI**: `--ai-reasoning-effort` オプションを追加。`build_llm_config_from_env` は環境変数 `MD2MAP_REASONING_EFFORT` にもフォールバック
- README（日英）の主要オプション表・CHANGELOG（日英）`[0.5.0] - Unreleased` に追記

## 後方互換性

`reasoning_effort` 未指定時の API 呼び出しは従来と完全に同一です。

## テスト

- `LLMConfig` のフィールド・デフォルト値
- 送信あり（base_url あり／なし）・未指定時の非送信
- CLI引数・環境変数フォールバック
- 計8件追加、全158テストがパス

## 関連

- elvezjp/spec-code-ai-reviewer#128（設定ファイルからの reasoningEffort 指定。本 PR マージ後、レビュアー側の分割 API から引き継ぎ可能になる）
- [Kimi K3 Thinking Effort](https://platform.kimi.ai/docs/guide/thinking-effort) / [OpenAI Reasoning models](https://developers.openai.com/api/docs/guides/reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)